### PR TITLE
Unpack CountBucket to give mean

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "julia.environmentPath": "/Users/phajy/Documents/GitHub/SWIFT_J0909"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "/Users/phajy/Documents/GitHub/SWIFT_J0909"
+}

--- a/src/valuebucket.jl
+++ b/src/valuebucket.jl
@@ -90,7 +90,7 @@ end
 
 Base.size(b::CountBucket) = size(b.output)
 function unpack_bucket(b::CountBucket)
-    [n > 0 ? o / n : 0 for (n, o) in zip(b.output, b.ncounts)]
+    [n > 0 ? o / n : 0 for (o, n) in zip(b.output, b.ncounts)]
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,7 +194,7 @@ end
         58201.07894736842,
     ]
     y_binned = bucket(X, y, bins; reduction = mean)
-    @test y_binned = [0.00019574174576036845, 0, 0, 0, 0]
+    @test y_binned ≈ [0.00019574174576036845, 0, 0, 0, 0] atol = 1e-3
 end
 
 @testset "mean" begin
@@ -203,9 +203,9 @@ end
     y = collect(1.0:length(X))
     bins = 1:11
     y_binned = bucket(X, y, bins; reduction = sum)
-    @test y_binned == [3.0, 7.0,11.0,15.0,19.0,23.0,27.0,31.0,35.0,39.0, 0.0]
+    @test y_binned ≈ [3.0, 7.0,11.0,15.0,19.0,23.0,27.0,31.0,35.0,39.0, 0.0] rtol = 1e-3
     y_binned = bucket(X, y, bins; reduction = mean)
-    @test y_binned == [1.5, 3.5, 5.5, 7.5, 9.5,11.5,13.5,15.5,17.5,19.5, 0]
+    @test y_binned ≈ [1.5, 3.5, 5.5, 7.5, 9.5,11.5,13.5,15.5,17.5,19.5, 0] rtol = 1e-3
 end
 
 # little bit of aqua

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,7 +177,6 @@ end
     @test y_binned == expected
 end
 
-
 @testset "#13" begin
     X = [58120.5, 58121.5, 58123.5, 58124.5, 58125.5]
     y = [
@@ -195,6 +194,18 @@ end
         58201.07894736842,
     ]
     y_binned = bucket(X, y, bins; reduction = mean)
+    @test y_binned = [0.00019574174576036845, 0, 0, 0, 0]
+end
+
+@testset "mean" begin
+    # generate known data
+    X = collect(range(1.1, 10.6, step = 0.5))
+    y = collect(1.0:length(X))
+    bins = 1:11
+    y_binned = bucket(X, y, bins; reduction = sum)
+    @test y_binned == [3.0, 7.0,11.0,15.0,19.0,23.0,27.0,31.0,35.0,39.0, 0.0]
+    y_binned = bucket(X, y, bins; reduction = mean)
+    @test y_binned == [1.5, 3.5, 5.5, 7.5, 9.5,11.5,13.5,15.5,17.5,19.5, 0]
 end
 
 # little bit of aqua

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,7 +194,7 @@ end
         58201.07894736842,
     ]
     y_binned = bucket(X, y, bins; reduction = mean)
-    @test y_binned ≈ [0.00019574174576036845, 0, 0, 0, 0] atol = 1e-3
+    @test y_binned ≈ [0.00019574174576036845, 0, 0, 0, 0] rtol = 1e-3
 end
 
 @testset "mean" begin


### PR DESCRIPTION
This pull request unpacks CountBucket to give mean. The changes include fixing the order of the variables in the list comprehension.